### PR TITLE
Fix incorrect hyperlink styling when hovering over a tool

### DIFF
--- a/src/sass/style.scss
+++ b/src/sass/style.scss
@@ -118,6 +118,12 @@ a {
           color: white;
           display: block;
         }
+        p {
+          a {
+            display: inline;
+            text-decoration: underline;
+          }
+        }
         [data-category="articles"] &{
           background: $yellow;
         }


### PR DESCRIPTION
Default state:

<img width="346" alt="screen shot 2016-10-15 at 10 45 46" src="https://cloud.githubusercontent.com/assets/39560/19409075/95372f7e-92c4-11e6-871d-2f6d35bc86d0.png">

Current broken hover state:

<img width="348" alt="screen shot 2016-10-15 at 10 45 50" src="https://cloud.githubusercontent.com/assets/39560/19409076/9bf14444-92c4-11e6-899f-23bcee1ae0bd.png">

Fixed hover state:

<img width="348" alt="screen shot 2016-10-15 at 10 45 34" src="https://cloud.githubusercontent.com/assets/39560/19409078/a550500c-92c4-11e6-87ab-1420eaf540e4.png">
